### PR TITLE
Do not convert zero values inside calc()

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -70,6 +70,10 @@ let tests = [{
     fixture: 'h1{width:calc(192px + 2em)}',
     expected: 'h1{width:calc(2in + 2em)}'
 }, {
+    message: 'should not convert zero values in calc',
+    fixture: 'h1{width:calc(0em)}',
+    expected: 'h1{width:calc(0em)}'
+}, {
     message: 'should not mangle values outside of its domain',
     fixture: 'h1{background:url(a.png)}',
     expected: 'h1{background:url(a.png)}'
@@ -84,7 +88,7 @@ let tests = [{
 }, {
     message: 'should optimise fractions inside calc',
     fixture: 'h1{width:calc(10.px + .0px)}',
-    expected: 'h1{width:calc(10px + 0)}'
+    expected: 'h1{width:calc(10px + 0px)}'
 }, {
     message: 'should handle leading zero in rem values',
     fixture: '.one{top:0.25rem}',

--- a/src/index.js
+++ b/src/index.js
@@ -4,29 +4,47 @@ import postcss from 'postcss';
 import convert from './lib/convert';
 import valueParser, {unit} from 'postcss-value-parser';
 
+function processValueNode (opts, node) {
+    if (node.type === 'word') {
+        let pair = unit(node.value);
+        if (pair) {
+            let num = Number(pair.number);
+            let u = pair.unit.toLowerCase();
+            if (num === 0) {
+                node.value = (u === 'ms' || u === 's') ? 0 + u : 0;
+            } else {
+                node.value = convert(num, u, opts);
+            }
+        }
+    }
+    if (node.type === 'function' && node.value !== 'calc') {
+        return false;
+    }
+}
+
+function walk (node, cb) {
+    var i, max, n;
+    if (node.nodes) {
+        for (i = 0, max = node.nodes.length; i < max; i += 1) {
+            n = node.nodes[i];
+            if (false !== cb(node.nodes[i])) {
+                walk(n, cb);
+            }
+        }
+    }
+    return node;
+}
+
 function transform (opts) {
     return decl => {
         if (~decl.prop.indexOf('flex')) {
             return;
         }
 
-        decl.value = valueParser(decl.value).walk(function (node) {
-            if (node.type === 'word') {
-                let pair = unit(node.value);
-                if (pair) {
-                    let num = Number(pair.number);
-                    let u = pair.unit.toLowerCase();
-                    if (num === 0) {
-                        node.value = (u === 'ms' || u === 's') ? 0 + u : 0;
-                    } else {
-                        node.value = convert(num, u, opts);
-                    }
-                }
-            }
-            if (node.type === 'function' && node.value !== 'calc') {
-                return false;
-            }
-        }).toString();
+        decl.value = walk(
+            valueParser(decl.value),
+            processValueNode.bind(null, opts)
+        ).toString();
     };
 }
 


### PR DESCRIPTION
`calc(0em)` gets converted into `calc(0)`, which is an invalid value:

- https://code.google.com/p/chromium/issues/detail?id=396003
- https://bugzilla.mozilla.org/show_bug.cgi?id=1041994

I've switched from using postValueParser's `walk` function into own so I could
determine whether value is used inside `calc()` function.

Sometimes I'm using `calc(0em)` for resetting fallback given for non-calc
browsers, because it has wider support than `@supports`
(http://caniuse.com/#feat=css-featurequeries,calc), like so:

```css
div
{
    /* fallback */
    border-right-width: 10em;
    …

    /* styles for browsers supporting calc() */
    border-right-width: calc(0em);
    …
}
```