### PR TITLE
Do not remove the unit from zero values in custom properties.

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -20,6 +20,10 @@ const suites = [{
     fixture: 'h1{transition-duration:0s}',
     expected: 'h1{transition-duration:0s}',
 }, {
+    message: 'should not remove the unit from zero values (custom properties)',
+    fixture: 'h1{--my-variable:0px}',
+    expected: 'h1{--my-variable:0px}',
+}, {
     message: 'should remove unnecessary plus signs',
     fixture: 'h1{width:+14px}',
     expected: 'h1{width:14px}',

--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,7 @@ function shouldStripPercent ({value, prop, parent}) {
 
 function transform (opts) {
     return decl => {
-        if (~decl.prop.indexOf('flex')) {
+        if (~decl.prop.indexOf('flex') || decl.prop.indexOf('--') === 0) {
             return;
         }
 


### PR DESCRIPTION
Fixes https://github.com/ben-eb/cssnano/issues/286.