### PR TITLE
fix ben-eb/cssnano#342

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -230,6 +230,10 @@ const suites = [{
     message: 'should keep stripping zeroes from shape-image-threshold',
     fixture: 'h1{shape-image-threshold:0.0625}',
     expected: 'h1{shape-image-threshold:.0625}',
+}, {
+    message: 'should keep unknown units or hacks',
+    fixture: 'h1{top:0\\9\\0;left:0lightyear}',
+    expected: 'h1{top:0\\9\\0;left:0lightyear}',
 }];
 
 ['stroke-dasharray', 'stroke-dashoffset', 'stroke-width'].forEach(property => {

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,11 @@ import postcss from 'postcss';
 import valueParser, {unit, walk} from 'postcss-value-parser';
 import convert from './lib/convert';
 
+const LENGTH_UNITS = [
+    'em', 'ex', 'ch', 'rem', 'vw', 'vh', 'vmin', 'vmax',
+    'cm', 'mm', 'q', 'in', 'pt', 'pc', 'px',
+];
+
 function parseWord (node, opts, keepZeroUnit) {
     const pair = unit(node.value);
     if (pair) {
@@ -10,12 +15,8 @@ function parseWord (node, opts, keepZeroUnit) {
         if (num === 0) {
             node.value = (
                 keepZeroUnit ||
-                u === 'ms' ||
-                u === 's' ||
-                u === 'deg'||
-                u === 'rad' ||
-                u === 'grad' ||
-                u === 'turn') ? 0 + u : 0;
+                !~LENGTH_UNITS.indexOf(u) && u !== '%'
+            ) ? 0 + u : 0;
         } else {
             node.value = convert(num, u, opts);
 


### PR DESCRIPTION
Keep unknown units & hacks by only stripping known length units & `%`.